### PR TITLE
Interface 'Twig_LoaderInterface' not found

### DIFF
--- a/init.php
+++ b/init.php
@@ -1,4 +1,8 @@
-<?php
+<?php defined('SYSPATH') or die('No direct script access.');
+
+define('TWIGPATH', __DIR__ . DIRECTORY_SEPARATOR);
+
+include Kohana::find_file('vendor', 'autoload');
 
 // Prepare twig environment
 Twig::init();


### PR DESCRIPTION
I have an error message using default script init.php on koseven framework:
ErrorException [ Fatal Error ]: Interface 'Twig_LoaderInterface' not found

I add a few lines by following koseven earlier version is kohana standard code. And it works!
Just info, Im using MAC, PHP7 and NGINX environtment for testing.